### PR TITLE
preserve backtrace when reraising response error

### DIFF
--- a/lib/apidiesel/errors.rb
+++ b/lib/apidiesel/errors.rb
@@ -3,7 +3,7 @@ module Apidiesel
   class InputError < Error; end
 
   class RequestError < Error
-    attr_reader :request
+    attr_accessor :request
 
     def initialize(msg = nil, request = nil)
       @request = request

--- a/lib/apidiesel/request.rb
+++ b/lib/apidiesel/request.rb
@@ -25,7 +25,8 @@ module Apidiesel
       begin
         @result = action.process_response(response_body)
       rescue ResponseError => e
-        raise ResponseError.new(e.message, self)
+        e.request = self
+        raise e
       end
     end
 


### PR DESCRIPTION
Changes reraising behaviour for `ResponseError`
