### PR TITLE
Prevent overwriting error message

### DIFF
--- a/lib/apidiesel/dsl.rb
+++ b/lib/apidiesel/dsl.rb
@@ -595,7 +595,8 @@ module Apidiesel
 
       def error_message(message, data)
         return message if message.is_a?(String)
-        message.call(data)
+        return message.call(data) if message.respond_to?(:call)
+        'unknown error'
       end
 
       def create_primitive_formatter(cast_method_symbol, *args, **kargs)

--- a/lib/apidiesel/dsl.rb
+++ b/lib/apidiesel/dsl.rb
@@ -587,13 +587,16 @@ module Apidiesel
         response_formatters << lambda do |data, processed_data|
           return processed_data unless callable.call(data)
 
-          message = message.is_a?(String) ? message : message.call(data)
-
-          raise ResponseError.new(message)
+          raise ResponseError.new(error_message(message, data))
         end
       end
 
-        protected
+      protected
+
+      def error_message(message, data)
+        return message if message.is_a?(String)
+        message.call(data)
+      end
 
       def create_primitive_formatter(cast_method_symbol, *args, **kargs)
         args = normalize_arguments(args, kargs)


### PR DESCRIPTION
If the error message parameter of response_error_if is defined as lamda or proc, next time it will be overwritten by the result of them self. 

First call of response_formatters will set message to the result of the proc/lamda. 
`message = message.is_a?(String) ? message : message.call(data)`

Next call of response_formatters it returns the result of first run because message is set to a string. So every time message is the same.
