### PR TITLE
prevent running on nil

### DIFF
--- a/lib/apidiesel/dsl.rb
+++ b/lib/apidiesel/dsl.rb
@@ -361,10 +361,12 @@ module Apidiesel
 
           value = apply_filter(args[:prefilter], value)
 
-          if args.has_key?(:on_error)
-            value = Date.strptime(value, args[:format]) rescue args[:on_error]
-          else
-            value = Date.strptime(value, args[:format])
+          if value.present?
+            if args.has_key?(:on_error)
+              value = Date.strptime(value, args[:format]) rescue args[:on_error]
+            else
+              value = Date.strptime(value, args[:format])
+            end
           end
 
           value = apply_filter(args[:postfilter] || args[:filter], value)


### PR DESCRIPTION
We found a bug when an excepted field was empty. Apidiesel will throw an exception and stops the process of handling the request answer. We have to interact even if there is an requested empty field.
